### PR TITLE
Disable scan button during the scan

### DIFF
--- a/src/js/scan.js
+++ b/src/js/scan.js
@@ -21,19 +21,19 @@ import { downloadReport } from "./include/download";
 
   activeOnlySwitch.on("change", function () {
     init(checkerList);
-	$("#runButton").prop('disabled', false);
+    $("#runButton").prop("disabled", false);
   });
 
   $("#cleanupButton").on("click", function (event) {
     event.preventDefault();
-	$("#runButton").prop('disabled', false);
+    $("#runButton").prop("disabled", false);
     init(checkerList);
   });
 
   $("#runButton").on("click", function (event) {
     event.preventDefault();
     runNextJob();
-	$(this).prop('disabled', true);
+    $(this).prop("disabled", true);
   });
 
   $(document).on("click", ".wpe-pcc-php-version-errors", function (event) {

--- a/src/js/scan.js
+++ b/src/js/scan.js
@@ -21,16 +21,19 @@ import { downloadReport } from "./include/download";
 
   activeOnlySwitch.on("change", function () {
     init(checkerList);
+	$("#runButton").prop('disabled', false);
   });
 
   $("#cleanupButton").on("click", function (event) {
     event.preventDefault();
+	$("#runButton").prop('disabled', false);
     init(checkerList);
   });
 
   $("#runButton").on("click", function (event) {
     event.preventDefault();
     runNextJob();
+	$(this).prop('disabled', true);
   });
 
   $(document).on("click", ".wpe-pcc-php-version-errors", function (event) {

--- a/src/js/scan.js
+++ b/src/js/scan.js
@@ -16,21 +16,22 @@ import { downloadReport } from "./include/download";
   window.phpcompat.results = [];
 
   const activeOnlySwitch = $("input[type=radio][name=active_plugins]");
+  const runButton = $("#runButton");
 
   init(checkerList);
 
   activeOnlySwitch.on("change", function () {
     init(checkerList);
-    $("#runButton").prop("disabled", false);
+    runButton.prop("disabled", false);
   });
 
   $("#cleanupButton").on("click", function (event) {
     event.preventDefault();
-    $("#runButton").prop("disabled", false);
+    runButton.prop("disabled", false);
     init(checkerList);
   });
 
-  $("#runButton").on("click", function (event) {
+  runButton.on("click", function (event) {
     event.preventDefault();
     runNextJob();
     $(this).prop("disabled", true);


### PR DESCRIPTION
### Description of the Change

Scan button is disabled when the scan starts. It is enabled back on a reset event:

1. "Clear results" link is clicked
2. Plugin / Theme Status radio is changed