### PR TITLE
Handle successful API responses that don't contain report data

### DIFF
--- a/src/js/include/render.js
+++ b/src/js/include/render.js
@@ -44,6 +44,20 @@ export function initResults(itemsToScan, activeOnly) {
 }
 
 export function updateResult(response, job) {
+  const report = response.reports?.phpcs_phpcompatibilitywp?.report;
+
+  // If we have a success response but don't have report data, show an error.
+  if (!report) {
+    updateResultFailure(
+      {
+        status: "failed",
+        message: __("No scan results found", "wpe-php-compat"),
+      },
+      job
+    );
+    return;
+  }
+
   const resultItem = $(`#${job.type}_${job.slug}`);
   const template = $("#result-template").html().toString();
 
@@ -51,8 +65,6 @@ export function updateResult(response, job) {
   const view = {
     ...job,
   };
-
-  const report = response.reports?.phpcs_phpcompatibilitywp?.report;
 
   // Success if no errors.
   view.status =

--- a/src/js/include/render.js
+++ b/src/js/include/render.js
@@ -51,7 +51,7 @@ export function updateResult(response, job) {
     updateResultFailure(
       {
         status: "failed",
-        message: __("No scan results found", "wpe-php-compat"),
+        message: "No scan results found",
       },
       job
     );


### PR DESCRIPTION
### Description of the Change

Some plugins will return a success response from WP Tide but the actual response data it returns does not contain anything other than an `id` field. The main thing missing there is the report data that we need.

Right now that ends up causing a JS error that halts execution. This PR fixes that by checking to see if the data we want is there and if not, we return early with an error response.

### How to test the Change

Run a scan on a site with one of the following plugins:

- WooCommerce 6.5.1
- WooCommerce Square 3.1.0
- Jetpack 11.1

Prior to this change, you'd see an error in the console and the loading icon never goes away. And if there are other things still left to scan, they will never run.

After this change, you'll get an error message now and the scan will continue.